### PR TITLE
Add argument for custom headers

### DIFF
--- a/bbrest.py
+++ b/bbrest.py
@@ -11,15 +11,19 @@ class BbRest:
     version = ''
     functions = {}
 
-    def __init__(self, key, secret, url):
+    def __init__(self, key, secret, url, headers=None):
         #these variables are accessible in the class, but not externally.
         self.__key = key
         self.__secret = secret
         self.__url = url
+        self.__headers = headers
 
         #Authenticate the session
         session = requests.Session()
         payload = {'grant_type':'client_credentials'}
+
+        if self.__headers:
+            session.headers.update(self.__headers)
 
         #Sends a post to get the authentication token
         r = session.post(f"{self.__url}/learn/api/public/v1/oauth2/token",


### PR DESCRIPTION
Hi!

My Bb administrator requires me to use a custom user-agent header to access the REST API. This feature adds an optional argument that can contain it, such as:

`BbRest(url, key, secret, headers={'user-agent': 'mycode-groups/0.0.1'})`

Thanks for the great library and also for the consideration.
