### PR TITLE
Use shift-tab to get parameter list when using Jupyter Notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ r = bb.GetUs<Tab>
 
 Find the parameters of 'GetColumnGrade'
 ```python
-r = bb.GetColumnGrade(<Tab>)
+r = bb.GetColumnGrade(<Shift-Tab>)
 ```
   * columnId=
   * courseId=


### PR DESCRIPTION
A simple change on Jupyter Notebook usage to complete parameters.