### PR TITLE
redirect_uri is now a param so we can set it to the web application f…

### DIFF
--- a/bbrest.py
+++ b/bbrest.py
@@ -19,7 +19,7 @@ class BbRest:
     version = ''
     functions = {}
 
-    def __init__(self, key, secret, url, headers=None, code='', scope='read'):
+    def __init__(self, key, secret, url, headers=None, code='', scope='read', redirect_uri='https://localhost/'):
         #these variables are accessible in the class, but not externally.
         self.__key = key
         self.__secret = secret
@@ -101,14 +101,14 @@ class BbRest:
         self.method_generator()
 
         if code:
-            r = self.AuthorizationCode(params={'redirect_uri':'https://localhost/',
+            r = self.AuthorizationCode(params={'redirect_uri': redirect_uri,
                                         'response_type':'code', 
                                         'client_id':self.__key, 
                                         'scope':scope,
                                         'state':'DC1067EE-63B9-40FE-A0AD-B9AC069BF4B0'})
                             
             r = session.post(f"{self.__url}/learn/api/public/v1/oauth2/token",
-                     params = {'code':code, 'redirect_uri':'https://localhost/'},
+                     params = {'code':code, 'redirect_uri': redirect_uri},
                      data={'grant_type':'authorization_code'},
                      auth=(self.__key, self.__secret))
 
@@ -426,11 +426,11 @@ class BbRest:
         call_str = f"""You've used {used_calls} REST calls so far.\nYou have {calls_perc:.2f}% left until {reset_time.slang_time()}\nAfter that, they should reset"""
         print(call_str)
 
-    def get_auth_url(self, scope='read'):
+    def get_auth_url(self, scope='read', redirect_uri='https://localhost/'):
         #Not sure why, but the first call returns a different URL that breaks. 
         #Only on the second call do you get the right auth URL
         r = self.AuthorizationCode(params={
-                                            'redirect_uri':'https://localhost/',
+                                            'redirect_uri': redirect_uri,
                                             'response_type':'code', 
                                             'client_id':self.__key, 
                                             'scope':scope,
@@ -440,7 +440,7 @@ class BbRest:
         )
         if 'new_loc' not in r.url:
             r = self.AuthorizationCode(params={
-                                            'redirect_uri':'https://localhost/',
+                                            'redirect_uri': redirect_uri,
                                             'response_type':'code', 
                                             'client_id':self.__key, 
                                             'scope':scope,


### PR DESCRIPTION
…qdn and action that will do the work after the user logs into Bb Learn
Hey Matt - Here's a brief video explanation: https://onblackboard-my.sharepoint.com/:v:/g/personal/mark_kauffman_blackboard_com/EX570j61gwJHo-ruzA7dJE4Bf-3KJ570hw7kCQ0mvtaSWQ?e=JAlMkt

Summary: I made redirect_uri a parameter so that the BbRest code can be running on https://matts.server.com for example and Learn will redirect back there after you log in.