### PR TITLE
Added unique state, and optional state argument

### DIFF
--- a/bbrest.py
+++ b/bbrest.py
@@ -9,7 +9,7 @@ from aiohttp import web
 import urllib
 import urllib.parse as urlparse
 import re
-
+import uuid
 
 
 
@@ -455,16 +455,20 @@ class BbRest:
         call_str = f"""You've used {used_calls} REST calls so far.\nYou have {calls_perc:.2f}% left until {reset_time.slang_time()}\nAfter that, they should reset"""
         print(call_str)
 
-    def get_auth_url(self, scope="read", redirect_uri="https://localhost/"):
+    def get_auth_url(self, scope="read", redirect_uri="https://localhost/", state=None):
         # Not sure why, but the first call returns a different URL that breaks.
         # Only on the second call do you get the right auth URL
+        #
+        if not state:
+            state = str(uuid.uuid1())
+        
         r = self.AuthorizationCode(
             params={
                 "redirect_uri": redirect_uri,
                 "response_type": "code",
                 "client_id": self.__key,
                 "scope": scope,
-                "state": "DC1067EE-63B9-40FE-A0AD-B9AC069BF4B0",
+                "state": state,
             },
             sync=True,
         )
@@ -475,7 +479,7 @@ class BbRest:
                     "response_type": "code",
                     "client_id": self.__key,
                     "scope": scope,
-                    "state": "DC1067EE-63B9-40FE-A0AD-B9AC069BF4B0",
+                    "state": state,
                 },
                 sync=True,
             )


### PR DESCRIPTION
@mark-b-kauffman Rather than use a default of an example, it'll default to use a unique code that can be overwritten by a set value. 

For web integration : state will have to be defined to be secure.
For command line : it won't really matter - but random seems better than hardcoded.

Tested and it generates a unique state that can be seen in auth url, and the same state is in the redirect after authenticating. 